### PR TITLE
Allow Optional Registry Credentials

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -17,7 +17,11 @@ spec:
         redeployOnChange: {{ .Values.container.redeployOnChange | quote }}
     spec:
       restartPolicy: {{ .Values.container.restartPolicy }}
-      containers:   
+      {{- if .Values.imagePullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.imagePullSecret }}
+      {{- end }}
+      containers:
       - name: {{ .Values.name }}
         image: {{ .Values.image }}
         {{- if .Values.container.command }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,7 @@
 environment: development
 name: mine-support-calculation-service
 image: mine-support-calculation-service
+imagePullSecret:
 container:
   imagePullPolicy: IfNotPresent
   requestMemory: 30Mi


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/FPD-440

To deploy from a private registry into a Kubernetes cluster registry
credentials must be supplied. this PR adds configuration to the
deployment chart to allow authentication.